### PR TITLE
feat: load EODHD_API_KEY from .env for all API calls

### DIFF
--- a/data_engines_fundamentals/eodhistoricaldata_md.py
+++ b/data_engines_fundamentals/eodhistoricaldata_md.py
@@ -3,7 +3,7 @@ import requests
 import pandas as pd
 import logging
 import os
-import dotenv
+from dotenv import load_dotenv
 from datetime import datetime, timedelta
 from rich import print
 
@@ -20,14 +20,14 @@ class eodhistoricaldata_md:
         self.base_url = "https://eodhd.com/api"
         
         # Load environment variables from .env file
-        load_status = dotenv.load_dotenv()
+        load_status = load_dotenv()
         if load_status is False:
             logging.warning('Environment variables not loaded from .env file.')
-        
-        # Get API token from environment
-        self.api_token = os.getenv('EODHISTORICALDATA_API_TOKEN')
+
+        # Get API key from environment
+        self.api_token = os.getenv('EODHD_API_KEY')
         if not self.api_token:
-            logging.warning("EODHISTORICALDATA_API_TOKEN not found in environment. Using demo token for limited testing.")
+            logging.warning("EODHD_API_KEY not found in environment. Using demo token for limited testing.")
             self.api_token = "demo"  # Demo token for AAPL.US, TSLA.US, VTI.US, AMZN.US, BTC-USD.CC, EURUSD.FOREX
         
         self.session = requests.Session()

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,6 +97,7 @@ pyparsing==3.2.3
 pyppeteer==2.0.0
 pyquery==2.0.1
 python-dateutil==2.9.0.post0
+python-dotenv==1.1.0
 python-json-logger==3.3.0
 pytz==2025.2
 PyYAML==6.0.2


### PR DESCRIPTION
Closes #6

## Changes

- Switch env var from `EODHISTORICALDATA_API_TOKEN` to `EODHD_API_KEY` in `eodhistoricaldata_md.py`
- Use `from dotenv import load_dotenv` for cleaner import style
- Add `python-dotenv==1.1.0` to `requirements.txt`

Generated with [Claude Code](https://claude.ai/code)